### PR TITLE
Feature: Get topic suggestions for new links

### DIFF
--- a/grafbase/generated/index.ts
+++ b/grafbase/generated/index.ts
@@ -154,6 +154,7 @@ export type Schema = {
     getGlobalTopicLearningStatus?: string;
     getGlobalLinks?: Schema['getGlobalLinksOutput'];
     checkUrl?: string;
+    getSuggestionsForUrl?: string;
     stripe?: string;
   };
   'Mutation': {
@@ -190,6 +191,7 @@ export type Resolver = {
   'Query.getGlobalTopicLearningStatus': ResolverFn<Schema['Query'], { topicName: string,  }, string>
   'Query.getGlobalLinks': ResolverFn<Schema['Query'], {  }, Schema['getGlobalLinksOutput']>
   'Query.checkUrl': ResolverFn<Schema['Query'], { linkUrl: string,  }, string>
+  'Query.getSuggestionsForUrl': ResolverFn<Schema['Query'], { linkUrl: string,  }, string>
   'Query.stripe': ResolverFn<Schema['Query'], { plan: string, userEmail: string,  }, string>
   'Mutation.createUser': ResolverFn<Schema['Mutation'], { email: string,  }, string>
   'Mutation.deletePersonalLink': ResolverFn<Schema['Mutation'], { personalLinkId: string,  }, string>

--- a/grafbase/grafbase.config.ts
+++ b/grafbase/grafbase.config.ts
@@ -217,6 +217,12 @@ g.query("checkUrl", {
   resolver: "checkUrl"
 })
 
+g.query("getSuggestionsForUrl", {
+  args: { linkUrl: g.string() },
+  returns: g.string(),
+  resolver: "getSuggestionsForUrl"
+})
+
 g.query("stripe", {
   args: { plan: g.string(), userEmail: g.string() },
   returns: g.string(),

--- a/grafbase/grafbase.config.ts
+++ b/grafbase/grafbase.config.ts
@@ -200,6 +200,12 @@ g.query("getGlobalTopicLearningStatus", {
   resolver: "getGlobalTopicLearningStatus"
 })
 
+g.query("getGlobalTopicAnswer", {
+  args: { topicName: g.string(), question: g.string() },
+  returns: g.string(),
+  resolver: "getGlobalTopicAnswer"
+})
+
 g.query("getGlobalLinks", {
   args: {},
   returns: g.ref(

--- a/grafbase/grafbase.config.ts
+++ b/grafbase/grafbase.config.ts
@@ -2,7 +2,8 @@ import { config, g } from "@grafbase/sdk"
 export default config({
   schema: g,
   experimental: {
-    kv: true
+    kv: true,
+    ai: true
   },
   auth: {
     rules: (rules) => {

--- a/grafbase/resolvers/getGlobalTopicAnswer.ts
+++ b/grafbase/resolvers/getGlobalTopicAnswer.ts
@@ -1,0 +1,31 @@
+import { Context } from "@grafbase/sdk"
+import { GraphQLError } from "graphql"
+import { hankoIdFromToken } from "../lib/hanko-validate"
+
+export default async function getSuggestionsForUrlResolver(
+  root: any,
+  args: { topicName: string, question: string },
+  context: Context
+) {
+  try {
+    const hankoId = await hankoIdFromToken(context)
+    if (hankoId) {
+        const answer = await context.ai.textLlm({
+            model: 'meta/llama-2-7b-chat-int8',
+            messages: [
+              {
+                role: 'system', content: 'You are an expert on '.concat(args.topicName)
+              },
+              {
+                role: 'user', content: args.question
+              }
+            ]
+        })
+        console.log(answer);
+        return answer
+    }
+  } catch (err) {
+    console.error(err, { args })
+    throw new GraphQLError(JSON.stringify(err))
+  }
+}

--- a/grafbase/resolvers/getSuggestionsForUrl.ts
+++ b/grafbase/resolvers/getSuggestionsForUrl.ts
@@ -1,0 +1,58 @@
+import { Context } from "@grafbase/sdk"
+import { GraphQLError } from "graphql"
+import { hankoIdFromToken } from "../lib/hanko-validate"
+
+// for now its just a proxy to get the title to get around cors issue
+// TODO: in future, do call to db and check if we have a url like this
+// if yes, fill it with details we do have or at least let users pick the details
+// essentially check if it's a GlobalLink already + more
+export default async function getSuggestionsForUrlResolver(
+  root: any,
+  args: { linkUrl: string },
+  context: Context
+) {
+  try {
+    const hankoId = await hankoIdFromToken(context)
+    if (hankoId) {
+      const url = new URL(args.linkUrl)
+      const init = {
+        headers: {
+          "content-type": "text/html;charset=UTF-8"
+        }
+      }
+      const response = await fetch(url, init)
+      let title = ""
+      let description = ""
+      let summary = ""
+      const rewriter_title = new HTMLRewriter().on("title", {
+        text(text) {
+          title += text.text
+        }
+      })
+      const rewriter_description = new HTMLRewriter().on("meta[name='description' s]", {
+        element(element) {
+            description += element.getAttribute('content')
+          }
+      })
+      await rewriter_title.transform(response.clone()).text()
+      await rewriter_description.transform(response.clone()).text()
+      summary += title + " // " + description
+      if (title && description) {
+        console.log(args.linkUrl, summary)
+        return summary 
+      } else {
+        if (description) {
+            console.error("Title not found", args.linkUrl)
+            throw new GraphQLError("Title not found")    
+        }
+        else if (title) {
+            console.error("Description not found", args.linkUrl)
+            throw new GraphQLError("Description not found")
+        }
+      }
+    }
+  } catch (err) {
+    console.error(err, { args })
+    throw new GraphQLError(JSON.stringify(err))
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@codemirror/view": "^6.21.4",
+    "@qdrant/js-client-rest": "^1.6.0",
     "bnx": "^0.3.1",
     "clipboardy": "^4.0.0",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
This PR adds:

## Changes 

**Grafbase resolver to get topic suggestions on a new link**

Using a new link web page description from its meta tags we create an embedding for the link using the `baai/bge-large-en-v1.5` model and search in a Qdrant instance to get the most similar _GlobalTopic_ to the new link and suggest it.

**Grafbase resolver to get single questions answers from a global topic**

Passing the topic name and question as arguments to it, we use `meta/llama-2-7b-chat-int8` to set a prompt where the model is an expert on the given topic and answers questions on the said topic. The current setup only considers single questions answers, meaning it would not handle multi-step interactions yet.


## Limitations

The current setup only works on the web app as Grafbase ai workers integration does not work locally yet.